### PR TITLE
Fix/gene start del

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,5 @@
 # https://gist.github.com/domnikl/ccb8d0b82056fbe5cf7f4f145ac7f44b
-name: main
+name: Tests
 
 on:
   push:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grumpy"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 description = "Genetic analysis in Rust."
 license-file = "LICENSE"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Tests](https://github.com/oxfordmmm/grumpy/actions/workflows/test.yaml/badge.svg)](https://github.com/oxfordmmm/grumpy/actions/workflows/test.yaml)
+
 # grumpy
 Re-implementation of [gumpy](https://github.com/oxfordmmm/gumpy) in Rust for speed
 

--- a/src/gene.rs
+++ b/src/gene.rs
@@ -255,6 +255,9 @@ impl Gene {
                     if indel_size.unsigned_abs() as usize > *pos {
                         // Deletion may start in this gene, but needs truncating to just the part in this gene
                         _max_del_length = *pos as i64;
+                        if _max_del_length == 0 {
+                            _max_del_length = 1;
+                        }
                     }
                     let mut new_pos = 0;
                     if _max_del_length == i64::MAX {
@@ -583,6 +586,9 @@ impl Gene {
                 {
                     let bases_to_trim =
                         (position.genome_idx + alt.base.len() as i64 - last_pos - 1) as usize;
+                    if bases_to_trim == 0 {
+                        continue;
+                    }
                     alt.base = alt.base[0..alt.base.len() - bases_to_trim].to_string();
                 }
             }

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -6772,4 +6772,28 @@ mod tests {
             MinorType::COV
         ));
     }
+
+    #[test]
+    fn test_revcomp_first_base_del() {
+        // Test that a deletion of the first base is handled correctly
+        let mut genome = Genome::new("reference/NC_000962.3.gbk");
+        let vcf = VCFFile::new("test/revcomp-del-first-pos.vcf".to_string(), false, 3);
+        let mut sample = mutate(&genome, vcf);
+
+        let diff = GenomeDifference::new(genome.clone(), sample.clone(), MinorType::COV);
+
+        for variant in diff.variants.iter() {
+            assert_eq!(variant.variant, "2406843_del_c".to_string());
+        }
+        assert_eq!(diff.minor_variants.len(), 0);
+
+        let rv2147c_diff = GeneDifference::new(
+            genome.get_gene("Rv2147c".to_string()),
+            sample.get_gene("Rv2147c".to_string()),
+            MinorType::COV,
+        );
+
+        assert_eq!(rv2147c_diff.minor_mutations.len(), 0);
+        assert_eq!(rv2147c_diff.mutations[0].mutation, "1_del_g".to_string());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,19 +36,19 @@ fn main() {
     let mut sample = mutate(&reference, vcf);
     let sample_end = SystemTime::now();
 
-    // let target_gene = "rrl";
+    let target_gene = "Rv2147c";
 
     let genome_start = SystemTime::now();
     let mut difference = GenomeDifference::new(reference.clone(), sample.clone(), MinorType::COV);
     let genome_end = SystemTime::now();
     // println!("{:?}", difference.variants.iter().map(|variant| variant.variant.clone()).collect::<Vec<String>>());
     for variant in difference.variants.iter_mut() {
-        // if variant.gene_name.clone().is_none()
-        //     || (variant.gene_name.clone().is_some()
-        //         && variant.gene_name.clone().unwrap() != target_gene)
-        // {
-        //     continue;
-        // }
+        if variant.gene_name.clone().is_none()
+            || (variant.gene_name.clone().is_some()
+                && variant.gene_name.clone().unwrap() != target_gene)
+        {
+            continue;
+        }
         println!(
             "{:?}@{:?} --> {:?}",
             variant.gene_name,
@@ -57,12 +57,12 @@ fn main() {
         );
     }
     for variant in difference.minor_variants.iter_mut() {
-        // if variant.gene_name.clone().is_none()
-        //     || (variant.gene_name.clone().is_some()
-        //         && variant.gene_name.clone().unwrap() != target_gene)
-        // {
-        //     continue;
-        // }
+        if variant.gene_name.clone().is_none()
+            || (variant.gene_name.clone().is_some()
+                && variant.gene_name.clone().unwrap() != target_gene)
+        {
+            continue;
+        }
         println!(
             "{:?}@{:?} --> {:?}",
             variant.gene_name,
@@ -73,9 +73,9 @@ fn main() {
 
     let gene_start = SystemTime::now();
     for gene_name in sample.genes_with_mutations.clone().iter() {
-        // if gene_name != target_gene {
-        //     continue;
-        // }
+        if gene_name != target_gene {
+            continue;
+        }
         println!("{}", gene_name);
         let gene_diff = GeneDifference::new(
             reference.get_gene(gene_name.clone()),

--- a/test/revcomp-del-first-pos.vcf
+++ b/test/revcomp-del-first-pos.vcf
@@ -1,0 +1,20 @@
+##fileformat=VCFv4.2
+##source=minos, version 0.12.4
+##fileDate=2022-10-25
+##FORMAT=<ID=ALLELE_DP,Number=R,Type=Float,Description="Mean read depth of ref and each allele">
+##FORMAT=<ID=COV,Number=R,Type=Integer,Description="Number of reads on ref and alt alleles">
+##FORMAT=<ID=COV_TOTAL,Number=1,Type=Integer,Description="Total reads mapped at this site, from gramtools">
+##FORMAT=<ID=DP,Number=1,Type=Float,Description="Mean read depth of called allele (ie the ALLELE_DP of the called allele)">
+##FORMAT=<ID=FRS,Number=1,Type=Float,Description="Fraction of reads that support the genotype call">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GT_CONF,Number=1,Type=Float,Description="Genotype confidence. Difference in log likelihood of most likely and next most likely genotype">
+##minosMeanReadDepth=72.044
+##minosReadDepthVariance=1817.566
+##contig=<ID=NC_000962.3,length=4411532>
+##FORMAT=<ID=GT_CONF_PERCENTILE,Number=1,Type=Float,Description="Percentile of GT_CONF">
+##FILTER=<ID=MIN_FRS,Description="Minimum FRS of 0.9">
+##FILTER=<ID=MIN_DP,Description="Minimum DP of 2">
+##FILTER=<ID=MIN_GCP,Description="Minimum GT_CONF_PERCENTILE of 0.5">
+##FILTER=<ID=MAX_DP,Description="Maximum DP of 199.9427646539246 (= 3.0 standard deviations from the mean read depth 72.044)">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	site.01.iso.1.subject.01-DR0011.lab_id.DR0011.seq_reps.1
+NC_000962.3	2406842	.	AC	A	.	PASS	.	GT:DP:ALLELE_DP:FRS:COV_TOTAL:COV:GT_CONF:GT_CONF_PERCENTILE	1/1:94:0,94:1.0:94:0,94:598.3:74.67


### PR DESCRIPTION
Edge case where a deletion of a single base at the first base of a revcomp gene was giving invalid mutations. This should fix to correctly return the correct base deleted