### PR TITLE
fix: use `sum(cov)` rather than dp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grumpy"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Genetic analysis in Rust."
 license-file = "LICENSE"
@@ -20,6 +20,12 @@ rayon = "1.10.0"
 [profile.dev]
 opt-level = 3
 debug = 1
+lto = true
+
+[profile.release]
+opt-level = 3
+debug-assertions = true # Required else lto gives no optimisations???
+lto = true
 
 [lib]
 name = "grumpy"

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -2617,7 +2617,7 @@ mod tests {
         let genome_diff = GenomeDifference::new(reference.clone(), sample.clone(), MinorType::FRS);
         let expected_minor_variants = vec![
             Variant {
-                variant: "16c>g:0.114".to_string(),
+                variant: "16c>g:0.105".to_string(),
                 nucleotide_index: 16,
                 evidence: VCFRow {
                     position: 16,
@@ -2643,7 +2643,7 @@ mod tests {
                 gene_name: Some("A".to_string()),
             },
             Variant {
-                variant: "17c>t:0.114".to_string(),
+                variant: "17c>t:0.105".to_string(),
                 nucleotide_index: 17,
                 evidence: VCFRow {
                     position: 16,
@@ -2669,7 +2669,7 @@ mod tests {
                 gene_name: Some("A".to_string()),
             },
             Variant {
-                variant: "18c>g:0.114".to_string(),
+                variant: "18c>g:0.105".to_string(),
                 nucleotide_index: 18,
                 evidence: VCFRow {
                     position: 16,
@@ -3497,7 +3497,7 @@ mod tests {
                 evidence: vec![
                     Evidence {
                         cov: Some(68),
-                        frs: Some(OrderedFloat(68.0 / 70.0)),
+                        frs: Some(OrderedFloat(68.0 / 76.0)),
                         genotype: "1/1".to_string(),
                         call_type: AltType::SNP,
                         vcf_row: VCFRow {
@@ -3524,7 +3524,7 @@ mod tests {
                     },
                     Evidence {
                         cov: Some(68),
-                        frs: Some(OrderedFloat(68.0 / 70.0)),
+                        frs: Some(OrderedFloat(68.0 / 76.0)),
                         genotype: "1/1".to_string(),
                         call_type: AltType::SNP,
                         vcf_row: VCFRow {
@@ -3819,7 +3819,7 @@ mod tests {
                 evidence: vec![
                     Evidence {
                         cov: Some(8),
-                        frs: Some(OrderedFloat(8.0 / 70.0)),
+                        frs: Some(OrderedFloat(8.0 / 76.0)),
                         genotype: "1/1".to_string(),
                         call_type: AltType::SNP,
                         vcf_row: VCFRow {
@@ -3846,7 +3846,7 @@ mod tests {
                     },
                     Evidence {
                         cov: Some(8),
-                        frs: Some(OrderedFloat(8.0 / 70.0)),
+                        frs: Some(OrderedFloat(8.0 / 76.0)),
                         genotype: "1/1".to_string(),
                         call_type: AltType::SNP,
                         vcf_row: VCFRow {
@@ -3873,7 +3873,7 @@ mod tests {
                     },
                     Evidence {
                         cov: Some(8),
-                        frs: Some(OrderedFloat(8.0 / 70.0)),
+                        frs: Some(OrderedFloat(8.0 / 76.0)),
                         genotype: "1/1".to_string(),
                         call_type: AltType::SNP,
                         vcf_row: VCFRow {
@@ -4254,12 +4254,12 @@ mod tests {
 
         let expected_a_minor_mutations_frs = vec![
             Mutation {
-                mutation: "P5V:0.114".to_string(),
+                mutation: "P5V:0.105".to_string(),
                 gene: "A".to_string(),
                 evidence: vec![
                     Evidence {
                         cov: Some(8),
-                        frs: Some(OrderedFloat(8.0 / 70.0)),
+                        frs: Some(OrderedFloat(8.0 / 76.0)),
                         genotype: "1/1".to_string(),
                         call_type: AltType::SNP,
                         vcf_row: VCFRow {
@@ -4286,7 +4286,7 @@ mod tests {
                     },
                     Evidence {
                         cov: Some(8),
-                        frs: Some(OrderedFloat(8.0 / 70.0)),
+                        frs: Some(OrderedFloat(8.0 / 76.0)),
                         genotype: "1/1".to_string(),
                         call_type: AltType::SNP,
                         vcf_row: VCFRow {
@@ -4313,7 +4313,7 @@ mod tests {
                     },
                     Evidence {
                         cov: Some(8),
-                        frs: Some(OrderedFloat(8.0 / 70.0)),
+                        frs: Some(OrderedFloat(8.0 / 76.0)),
                         genotype: "1/1".to_string(),
                         call_type: AltType::SNP,
                         vcf_row: VCFRow {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
     let mut sample = mutate(&reference, vcf);
     let sample_end = SystemTime::now();
 
-    let target_gene = "Rv0043c";
+    let target_gene = "mmpL5";
 
     let genome_start = SystemTime::now();
     let mut difference = GenomeDifference::new(reference.clone(), sample.clone(), MinorType::COV);

--- a/src/vcf.rs
+++ b/src/vcf.rs
@@ -330,14 +330,8 @@ impl VCFFile {
         }
 
         let mut dp = 0;
-        if record.fields.contains_key("DP")
-            && record.fields.get("DP").unwrap()[0].parse::<i32>().is_ok()
-        {
-            dp = record.fields.get("DP").unwrap()[0].parse::<i32>().unwrap();
-        } else {
-            // If there isn't a valid DP field defined then default to the sum of the COV field
-            cov.iter().for_each(|x| dp += x);
-        }
+        // As DP isn't always reliable, default to the sum of the COV field
+        cov.iter().for_each(|x| dp += x);
 
         let ref_allele = record.reference.clone().to_lowercase();
         let mut alt_allele = "".to_string();


### PR DESCRIPTION
As `DP` is technically mean depth of reads at a given allele, it doesn't always produce correct FRS values