### PR TITLE
fix: ensure SNPs after deletions in VCF records are correctly parsed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grumpy"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "Genetic analysis in Rust."
 license-file = "LICENSE"

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -745,19 +745,16 @@ impl GeneDifference {
                             for (nc, cov, frs, ev) in minor_snps.iter() {
                                 codon += &nc.to_string();
                                 // Evidence is the only field which is None in the case of no minor SNP at this nc
-                                match ev {
-                                    Some(e) => {
-                                        for e in e.iter() {
-                                            minor_evidence.push(e.clone());
-                                        }
-                                        if cov.is_some() && cov.unwrap() > minor_cov {
-                                            minor_cov = cov.unwrap();
-                                        }
-                                        if frs.is_some() && frs.unwrap() > minor_frs {
-                                            minor_frs = frs.unwrap();
-                                        }
+                                if let Some(e) = ev {
+                                    for e in e.iter() {
+                                        minor_evidence.push(e.clone());
                                     }
-                                    None => {}
+                                    if cov.is_some() && cov.unwrap() > minor_cov {
+                                        minor_cov = cov.unwrap();
+                                    }
+                                    if frs.is_some() && frs.unwrap() > minor_frs {
+                                        minor_frs = frs.unwrap();
+                                    }
                                 }
                             }
                             let aa = codon_to_aa(codon.clone());

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -4728,4 +4728,34 @@ mod tests {
         assert_eq!(mymt_diff.mutations.len(), 0);
         assert_eq!(mymt_diff.minor_mutations.len(), 0);
     }
+
+    #[test]
+    fn test_snp_after_del() {
+        let mut genome = Genome::new("reference/NC_000962.3.gbk");
+        let vcf = VCFFile::new("test/tb-snp-after-del.vcf".to_string(), false, 3);
+        let mut sample = mutate(&genome, vcf);
+
+        let diff = GenomeDifference::new(genome.clone(), sample.clone(), MinorType::COV);
+
+        let expected_variants = [
+            "1224300_del_tgcgcctcccgcgagcagacacagaatcgcactgcgccggcccggcgcgtgcgattctgtgtctg",
+            "1224367t>c",
+        ];
+        for (idx, variant) in diff.variants.iter().enumerate() {
+            assert_eq!(variant.variant, expected_variants[idx]);
+        }
+        assert_eq!(diff.minor_variants.len(), 0);
+
+        let rv1096_diff = GeneDifference::new(
+            genome.get_gene("Rv1096".to_string()),
+            sample.get_gene("Rv1096".to_string()),
+            MinorType::COV,
+        );
+        assert_eq!(rv1096_diff.minor_mutations.len(), 0);
+        assert_eq!(
+            rv1096_diff.mutations[0].mutation,
+            "-85_del_tgcgcctcccgcgagcagacacagaatcgcactgcgccggcccggcgcgtgcgattctgtgtctg".to_string()
+        );
+        assert_eq!(rv1096_diff.mutations[1].mutation, "t-18c".to_string());
+    }
 }

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -377,7 +377,9 @@ impl Genome {
             let gene = self.build_gene(gene_name.clone());
             self.genes.insert(gene_name.clone(), gene);
         }
-        return self.genes.get(&gene_name).unwrap().clone();
+
+        // I hate implicit returns, but appease clippy
+        self.genes.get(&gene_name).unwrap().clone()
     }
 
     /// Get the data at a given genome index

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
     let mut sample = mutate(&reference, vcf);
     let sample_end = SystemTime::now();
 
-    let target_gene = "mmpL5";
+    let target_gene = "Rv1096";
 
     let genome_start = SystemTime::now();
     let mut difference = GenomeDifference::new(reference.clone(), sample.clone(), MinorType::COV);

--- a/test/tb-snp-after-del.vcf
+++ b/test/tb-snp-after-del.vcf
@@ -1,0 +1,47 @@
+##fileformat=VCFv4.2
+##source=minos, version 0.12.5
+##fileDate=2024-12-11
+##minosMeanReadDepth=64.907
+##minosReadDepthVariance=2334.957
+##contig=<ID=NC_000962.3,length=4411532>
+##FORMAT=<ID=ALLELE_DP,Number=R,Type=Float,Description="Mean read depth of ref and each allele">
+##FORMAT=<ID=COV,Number=R,Type=Integer,Description="Number of reads on ref and alt alleles">
+##FORMAT=<ID=COV_TOTAL,Number=1,Type=Integer,Description="Total reads mapped at this site, from gramtools">
+##FORMAT=<ID=DP,Number=1,Type=Float,Description="Mean read depth of called allele (ie the ALLELE_DP of the called allele)">
+##FORMAT=<ID=FRS,Number=1,Type=Float,Description="Fraction of reads that support the genotype call">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GT_CONF,Number=1,Type=Float,Description="Genotype confidence. Difference in log likelihood of most likely and next most likely genotype">
+##FORMAT=<ID=GT_CONF_PERCENTILE,Number=1,Type=Float,Description="Percentile of GT_CONF">
+##FORMAT=<ID=AC1,Number=1,Type=Float,Description="Max-likelihood estimate of the first ALT allele count (no HWE assumption)">
+##FORMAT=<ID=AF1,Number=1,Type=Float,Description="Max-likelihood estimate of the first ALT allele frequency (assuming HWE)">
+##FORMAT=<ID=AF2,Number=1,Type=Float,Description="Max-likelihood estimate of the first and second group ALT allele frequency (assuming HWE)">
+##FORMAT=<ID=BQBZ,Number=1,Type=Float,Description="Mann-Whitney U-z test of Base Quality Bias (closer to 0 is better)">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Raw read depth">
+##FORMAT=<ID=DP4,Number=4,Type=Integer,Description="Number of high-quality ref-forward , ref-reverse, alt-forward and alt-reverse bases">
+##FORMAT=<ID=DP_ACGT,Number=8,Type=Integer,Description="Number of A-forward, A-reverse, C-forward, C-reverse, G-forward, G-reverse, T-forward, T-reverse bases">
+##FORMAT=<ID=FQ,Number=1,Type=Float,Description="Phred probability of all samples being the same">
+##FORMAT=<ID=FS,Number=1,Type=Float,Description="Phred-scaled p-value using Fisher's exact test to detect strand bias">
+##FORMAT=<ID=G3,Number=3,Type=Float,Description="ML estimate of genotype frequencies">
+##FORMAT=<ID=HWE,Number=1,Type=Float,Description="Chi^2 based HWE test P-value based on G3">
+##FORMAT=<ID=IDV,Number=1,Type=Integer,Description="Maximum number of raw reads supporting an indel">
+##FORMAT=<ID=IMF,Number=1,Type=Float,Description="Maximum fraction of raw reads supporting an indel">
+##FORMAT=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##FORMAT=<ID=MQ,Number=1,Type=Integer,Description="Root-mean-square mapping quality of covering reads">
+##FORMAT=<ID=MQ0F,Number=1,Type=Float,Description="Fraction of MQ0 reads (smaller is better)">
+##FORMAT=<ID=MQBZ,Number=1,Type=Float,Description="Mann-Whitney U-z test of Mapping Quality Bias (closer to 0 is better)">
+##FORMAT=<ID=MQSBZ,Number=1,Type=Float,Description="Mann-Whitney U-z test of Mapping Quality vs Strand Bias (closer to 0 is better)">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="List of Phred-scaled genotype likelihoods">
+##FORMAT=<ID=PV4,Number=4,Type=Float,Description="P-values for strand bias, baseQ bias, mapQ bias and tail distance bias">
+##FORMAT=<ID=RPBZ,Number=1,Type=Float,Description="Mann-Whitney U-z test of Read Position Bias (closer to 0 is better)">
+##FORMAT=<ID=SCBZ,Number=1,Type=Float,Description="Mann-Whitney U-z test of Soft-Clip Length Bias (closer to 0 is better)">
+##FORMAT=<ID=SGB,Number=1,Type=Float,Description="Segregation based metric.">
+##FORMAT=<ID=VDB,Number=1,Type=Float,Description="Variant Distance Bias for filtering splice-site artefacts in RNA-seq data (bigger is better)",Version="3">
+##INFO=<ID=CALLER,Number=1,Description="Origin of call, one of minos, samtools, or none if there was no depth">
+##FILTER=<ID=MIN_FRS,Description="Minimum FRS of 0.9">
+##FILTER=<ID=MIN_DP,Description="Minimum DP of 3">
+##FILTER=<ID=MIN_GCP,Description="Minimum GT_CONF_PERCENTILE of 0.5">
+##FILTER=<ID=MAX_DP,Description="Maximum DP of 209.8711783338215 (= 3.0 standard deviations from the mean read depth 64.907)">
+##FILTER=<ID=NO_DATA,Description="No information from minos or samtools">
+##FILTER=<ID=PASS,Description="All filters passed">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample
+NC_000962.3	1224298	.	AGTGCGCCTCCCGCGAGCAGACACAGAATCGCACTGCGCCGGCCCGGCGCGTGCGATTCTGTGTCTGCTT	AGCTC	.	PASS	.	GT:DP:ALLELE_DP:FRS:COV_TOTAL:COV:GT_CONF:GT_CONF_PERCENTILE	1/1:62.6:0.0143,62.6:1.0:64:0,60:378.9:55.22


### PR DESCRIPTION
This is evidently less common than you'd think as this wasn't picked up in >1000 samples. 

Essentially, in cases where a single VCF row defines a deletion and a SNP (where the SNP lies after the deletion), grumpy was erroneously placing the SNP in the wrong place (incorrect position as well as incorrect reference base). This very simply fixes this