### PR TITLE
fix: CI fixes for compiling py03

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,8 +122,6 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-12
-            target: x86_64
           - runner: macos-14
             target: aarch64
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grumpy"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "Genetic analysis in Rust."
 license-file = "LICENSE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 # 'grumpy' is taken on PyPi, but we can still use `import grumpy` after a `pip install bio-grumpy`
 name = "bio-grumpy"
-requires-python = ">=3.8"
+requires-python = " >=3.8,<3.13"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Programming Language :: Rust",


### PR DESCRIPTION
Lots of fun issues around python having no GIL here https://github.com/oxfordmmm/grumpy/actions/runs/12296110424/job/34314435645, so restrict python version to <3.13 (which is where no GIL became an option)

Also removes the now depreciated MacOS12 build