### PR TITLE
fix: enable output of variable length fasta for genomes + rework CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ mprofile*
 perf.data*
 tarpaulin-*.html
 edge-cases.md
+
+*.fasta
+*.msh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grumpy"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "Genetic analysis in Rust."
 license-file = "LICENSE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ vcf = "0.6.1"
 pyo3 = { version = "0.25.0", features = ["extension-module"] }
 pretty_assertions = "1.4.0"
 rayon = "1.10.0"
+clap = { version = "4.5.40", features = ["derive"] }
 
 [profile.dev]
 opt-level = 3

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -468,9 +468,7 @@ impl Genome {
                     // Insertions are a bit more complex, we need to insert the bases
                     // at this position
                     // We only want to do this in cases of a clear, single alt's insertion
-                    for ins_alt in ins.iter() {
-                        nc_sequence.push_str(&ins_alt.base);
-                    }
+                    nc_sequence.push_str(&ins[0].base);
                 }
             }
         }

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -3,6 +3,7 @@ use pyo3::prelude::*;
 
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
+use std::io::Write;
 
 use gb_io::reader::SeqReader;
 use gb_io::seq::Location::Complement;
@@ -409,6 +410,82 @@ impl Genome {
             panic!("No VCF records associated with this genome");
         }
         self.vcf_records.as_ref().unwrap()[index].clone()
+    }
+
+    /// Write the genome (including indels) to a FASTA file
+    ///
+    /// # Arguments
+    /// - `filename` - Name of the file to write to
+    pub fn write_fasta(&self, filename: &str) {
+        let mut nc_sequence = String::new();
+        for position in self.genome_positions.iter() {
+            if position.is_deleted {
+                // Position deleted, so skip it
+                continue;
+            }
+            // Only alts we care about now are SNPs, nulls and ins
+            // It's possible that we have both a SNP/null and an ins at a given position
+            // So check for both
+
+            let alts = position
+                .alts
+                .iter()
+                .filter(|alt| {
+                    alt.alt_type == AltType::SNP
+                        || alt.alt_type == AltType::NULL
+                        || alt.alt_type == AltType::INS
+                })
+                .cloned()
+                .collect::<Vec<Alt>>();
+
+            if alts.is_empty() {
+                // No mutations at this position, so just add the reference base
+                nc_sequence.push(position.reference);
+            } else {
+                let snps = alts
+                    .iter()
+                    .filter(|alt| alt.alt_type == AltType::SNP || alt.alt_type == AltType::NULL)
+                    .collect::<Vec<&Alt>>();
+
+                if snps.len() != 1 {
+                    // No SNPs or het here so reference base
+                    nc_sequence.push(position.reference);
+                } else {
+                    // Only one SNP, so use that
+                    let mut snp = snps[0].base.chars().next().unwrap();
+                    if snp == 'x' {
+                        // We use X internally for null calls, but N is the valid character in fastas
+                        snp = 'n';
+                    }
+                    nc_sequence.push(snp);
+                }
+
+                let ins = alts
+                    .iter()
+                    .filter(|alt| alt.alt_type == AltType::INS)
+                    .collect::<Vec<&Alt>>();
+                if ins.len() == 1 {
+                    // Insertions are a bit more complex, we need to insert the bases
+                    // at this position
+                    // We only want to do this in cases of a clear, single alt's insertion
+                    for ins_alt in ins.iter() {
+                        nc_sequence.push_str(&ins_alt.base);
+                    }
+                }
+            }
+        }
+
+        // Write the sequence to a FASTA file
+        let mut fasta_file = File::create(filename).expect("Unable to create FASTA file");
+        writeln!(fasta_file, ">{}", self.name).expect("Unable to write to FASTA file");
+        for (idx, c) in nc_sequence.chars().enumerate() {
+            let idx = idx + 1;
+            write!(fasta_file, "{}", c.to_uppercase()).expect("Unable to write to FASTA file");
+            if idx % 80 == 0 {
+                // Add a newline every 80 characters
+                writeln!(fasta_file).expect("Unable to write to FASTA file");
+            }
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
-use std::env;
 use std::time::SystemTime;
+
+use clap::Parser;
 
 pub mod common;
 pub mod difference;
@@ -14,109 +15,132 @@ use genome::mutate;
 use genome::Genome;
 use vcf::VCFFile;
 
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// Path to the reference genbank file
+    #[arg(long)]
+    reference: String,
+
+    /// Path to the VCF file
+    #[arg(long)]
+    vcf: String,
+
+    /// Target gene name. If given, pull out all variants and mutations within this gene
+    #[arg(long)]
+    gene: Option<String>,
+
+    /// Path to the output variable length FASTA file. If given, the sample genome will be written to this file
+    #[arg(long)]
+    fasta: Option<String>,
+}
+
 #[cfg(not(tarpaulin_include))]
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() != 3 {
-        println!("Usage: grumpy <reference_genome> <vcf_file>");
-        return;
-    }
-    let reference_path = &args[1];
-    let vcf_path = &args[2];
+    let args = Args::parse();
+
+    let reference_path = args.reference;
+    let vcf_path = args.vcf;
 
     let vcf_start = SystemTime::now();
     let vcf = VCFFile::new(vcf_path.to_string(), false, 3);
     let vcf_end = SystemTime::now();
 
     let reference_start = SystemTime::now();
-    let mut reference = Genome::new(reference_path);
+    let mut reference = Genome::new(&reference_path);
     let reference_end = SystemTime::now();
 
     let sample_start = SystemTime::now();
     let mut sample = mutate(&reference, vcf);
     let sample_end = SystemTime::now();
 
-    let target_gene = "yrbE3A";
-
-    let genome_start = SystemTime::now();
-    let mut difference = GenomeDifference::new(reference.clone(), sample.clone(), MinorType::COV);
-    let genome_end = SystemTime::now();
-    // println!("{:?}", difference.variants.iter().map(|variant| variant.variant.clone()).collect::<Vec<String>>());
-    for variant in difference.variants.iter_mut() {
-        if variant.gene_name.clone().is_none()
-            || (variant.gene_name.clone().is_some()
-                && variant.gene_name.clone().unwrap() != target_gene)
-        {
-            continue;
+    // If given a gene name, pull out the genome and gene level differences
+    if let Some(target_gene) = args.gene {
+        let genome_start = SystemTime::now();
+        let mut difference =
+            GenomeDifference::new(reference.clone(), sample.clone(), MinorType::COV);
+        let genome_end = SystemTime::now();
+        for variant in difference.variants.iter_mut() {
+            if variant.gene_name.clone().is_none()
+                || (variant.gene_name.clone().is_some()
+                    && variant.gene_name.clone().unwrap() != target_gene)
+            {
+                continue;
+            }
+            println!(
+                "{:?}@{:?} --> {:?}",
+                variant.gene_name,
+                variant.gene_position,
+                variant.variant.clone()
+            );
         }
+        for variant in difference.minor_variants.iter_mut() {
+            if variant.gene_name.clone().is_none()
+                || (variant.gene_name.clone().is_some()
+                    && variant.gene_name.clone().unwrap() != target_gene)
+            {
+                continue;
+            }
+            println!(
+                "{:?}@{:?} --> {:?}",
+                variant.gene_name,
+                variant.gene_position,
+                variant.variant.clone()
+            );
+        }
+
+        let gene_start = SystemTime::now();
+        for gene_name in sample.genes_with_mutations.clone().iter() {
+            if gene_name != &target_gene {
+                continue;
+            }
+            println!("{}", gene_name);
+            let gene_diff = GeneDifference::new(
+                reference.get_gene(gene_name.clone()),
+                sample.get_gene(gene_name.clone()),
+                MinorType::COV,
+            );
+            println!(
+                "{:?}",
+                gene_diff
+                    .mutations
+                    .iter()
+                    .map(|mutation| mutation.mutation.clone())
+                    .collect::<Vec<String>>()
+            );
+            println!(
+                "{:?}\n",
+                gene_diff
+                    .minor_mutations
+                    .iter()
+                    .map(|mutation| mutation.mutation.clone())
+                    .collect::<Vec<String>>()
+            );
+        }
+        let gene_end = SystemTime::now();
+
+        println!("\n-----------------------------------\n");
+        println!("VCF took {:?}", vcf_end.duration_since(vcf_start).unwrap());
         println!(
-            "{:?}@{:?} --> {:?}",
-            variant.gene_name,
-            variant.gene_position,
-            variant.variant.clone()
+            "Reference took {:?}",
+            reference_end.duration_since(reference_start).unwrap()
+        );
+        println!(
+            "Sample took {:?}",
+            sample_end.duration_since(sample_start).unwrap()
+        );
+        println!(
+            "Genome diff took {:?}",
+            genome_end.duration_since(genome_start).unwrap()
+        );
+        println!(
+            "Gene diff took {:?}",
+            gene_end.duration_since(gene_start).unwrap()
         );
     }
-    for variant in difference.minor_variants.iter_mut() {
-        if variant.gene_name.clone().is_none()
-            || (variant.gene_name.clone().is_some()
-                && variant.gene_name.clone().unwrap() != target_gene)
-        {
-            continue;
-        }
-        println!(
-            "{:?}@{:?} --> {:?}",
-            variant.gene_name,
-            variant.gene_position,
-            variant.variant.clone()
-        );
-    }
 
-    let gene_start = SystemTime::now();
-    for gene_name in sample.genes_with_mutations.clone().iter() {
-        if gene_name != target_gene {
-            continue;
-        }
-        println!("{}", gene_name);
-        let gene_diff = GeneDifference::new(
-            reference.get_gene(gene_name.clone()),
-            sample.get_gene(gene_name.clone()),
-            MinorType::COV,
-        );
-        println!(
-            "{:?}",
-            gene_diff
-                .mutations
-                .iter()
-                .map(|mutation| mutation.mutation.clone())
-                .collect::<Vec<String>>()
-        );
-        println!(
-            "{:?}\n",
-            gene_diff
-                .minor_mutations
-                .iter()
-                .map(|mutation| mutation.mutation.clone())
-                .collect::<Vec<String>>()
-        );
+    // If a FASTA path is provided, write the sample genome to it
+    if let Some(fasta_path) = args.fasta {
+        sample.write_fasta(&fasta_path);
     }
-    let gene_end = SystemTime::now();
-
-    println!("\n-----------------------------------\n");
-    println!("VCF took {:?}", vcf_end.duration_since(vcf_start).unwrap());
-    println!(
-        "Reference took {:?}",
-        reference_end.duration_since(reference_start).unwrap()
-    );
-    println!(
-        "Sample took {:?}",
-        sample_end.duration_since(sample_start).unwrap()
-    );
-    println!(
-        "Genome diff took {:?}",
-        genome_end.duration_since(genome_start).unwrap()
-    );
-    println!(
-        "Gene diff took {:?}",
-        gene_end.duration_since(gene_start).unwrap()
-    );
 }


### PR DESCRIPTION
Allows for generation of synthetic reads from real samples. Also introduces a more robust CLI using `clap` (which is long overdue)